### PR TITLE
fix: bump CD workflow runner to ubuntu-20.04

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -27,7 +27,7 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   gnu_linux_armhf:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout the repository
       uses: actions/checkout@v2
@@ -60,7 +60,7 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   gnu_linux_aarch64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout the repository
       uses: actions/checkout@v2
@@ -93,7 +93,7 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   gnu_linux_x86_64:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout the repository
       uses: actions/checkout@v2


### PR DESCRIPTION
ubuntu-18.04 runners have been deprecated

https://docs.github.com/en/actions/using-jobs/choosing-the-runner-for-a-job#choosing-github-hosted-runners

<!--- Provide a general summary of your changes -->


## Related issue(s)

## Usage examples

```zsh

```

## How has this been tested?

## Types of changes

- [ ] Breaking change
- [ ] Bug fix
- [ ] Documentation
- [ ] New feature
